### PR TITLE
Duplicated Dependency_Injector inclusion

### DIFF
--- a/libraries/Notifications/Workflow/Step/Channel/Base.php
+++ b/libraries/Notifications/Workflow/Step/Channel/Base.php
@@ -9,14 +9,11 @@
 
 namespace PublishPress\Notifications\Workflow\Step\Channel;
 
-use PublishPress\Notifications\Traits\Dependency_Injector;
 use PublishPress\Notifications\Workflow\Step\Base as Base_Step;
 use WP_User;
 
 class Base extends Base_Step
 {
-    use Dependency_Injector;
-
     const META_KEY_EMAIL = '_psppno_chnbase';
 
     /**


### PR DESCRIPTION
The `Dependency_Injector` trait is already included in the `PublishPress\Notifications\Workflow\Step\Base` class from which `PublishPress\Notifications\Workflow\Step\Channel\Base` is inheriting. The usage of this trait resulted in the following warning:
```
PHP Strict Standards:  PublishPress\Notifications\Workflow\Step\Base and PublishPress\Notifications\Traits\Dependency_Injector define the same property ($container) in the composition of PublishPress\Notifications\Workflow\Step\Channel\Base. This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed in /var/www/content/plugins/publishpress/libraries/Notifications/Workflow/Step/Channel/Base.php on line 167
```